### PR TITLE
feat: Add reusable info page components

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,21 @@
   "name": "@toplocs/plugin-sdk",
   "version": "1.0.0",
   "description": "Official SDK for developing plugins for the TopLocs decentralized community platform",
-  "keywords": ["toplocs", "plugin", "sdk", "vue", "typescript", "module-federation"],
+  "keywords": [
+    "toplocs",
+    "plugin",
+    "sdk",
+    "vue",
+    "typescript",
+    "module-federation"
+  ],
   "homepage": "https://github.com/toplocs/plugin-sdk#readme",
   "bugs": {
     "url": "https://github.com/toplocs/plugin-sdk/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:toplocs/plugin-sdk.git"
+    "url": "git+ssh://git@github.com/toplocs/plugin-sdk.git"
   },
   "license": "MIT",
   "author": "TopLocs Team",

--- a/src/components/info-page/PluginCodeBlock.vue
+++ b/src/components/info-page/PluginCodeBlock.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="code-block">
+    <pre><code>{{ code }}</code></pre>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  code: string
+}
+
+defineProps<Props>()
+</script>
+
+<style scoped>
+.code-block {
+  background: #f4f4f4;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 1rem;
+  margin: 1rem 0;
+  overflow-x: auto;
+}
+
+pre {
+  margin: 0;
+  font-family: 'Courier New', monospace;
+}
+
+code {
+  color: #333;
+}
+</style>

--- a/src/components/info-page/PluginFeatureGrid.vue
+++ b/src/components/info-page/PluginFeatureGrid.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="feature-grid">
+    <div v-for="feature in features" :key="feature.title" class="feature">
+      <h3>{{ feature.icon }} {{ feature.title }}</h3>
+      <p>{{ feature.description }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Feature {
+  icon: string
+  title: string
+  description: string
+}
+
+interface Props {
+  features: Feature[]
+}
+
+defineProps<Props>()
+</script>
+
+<style scoped>
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.feature {
+  padding: 1rem;
+  background: #f8f9fa;
+  border-radius: 4px;
+}
+
+.feature h3 {
+  color: #34495e;
+  margin-bottom: 0.5rem;
+}
+
+.feature p {
+  margin: 0;
+  color: #666;
+}
+</style>

--- a/src/components/info-page/PluginHeader.vue
+++ b/src/components/info-page/PluginHeader.vue
@@ -1,0 +1,77 @@
+<template>
+  <header class="plugin-header">
+    <h1>{{ icon }} TopLocs {{ title }} Plugin</h1>
+    <p class="subtitle">{{ subtitle }}</p>
+    <span v-if="status" class="status-badge" :class="statusClass">{{ status }}</span>
+  </header>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Props {
+  title: string
+  subtitle?: string
+  icon?: string
+  status?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  icon: '🔌'
+})
+
+const statusClass = computed(() => {
+  if (!props.status) return ''
+  
+  const statusLower = props.status.toLowerCase()
+  if (statusLower.includes('federated') || statusLower.includes('modern')) return 'status-modern'
+  if (statusLower.includes('hybrid')) return 'status-hybrid'
+  if (statusLower.includes('legacy')) return 'status-legacy'
+  return ''
+})
+</script>
+
+<style scoped>
+.plugin-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+h1 {
+  font-size: 2.5rem;
+  color: #2c3e50;
+  margin-bottom: 1rem;
+}
+
+.subtitle {
+  font-size: 1.2rem;
+  color: #7f8c8d;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  color: white;
+  border-radius: 20px;
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+}
+
+.status-modern {
+  background: #27ae60;
+}
+
+.status-hybrid {
+  background: #f39c12;
+}
+
+.status-legacy {
+  background: #95a5a6;
+}
+
+@media (max-width: 600px) {
+  h1 {
+    font-size: 2rem;
+  }
+}
+</style>

--- a/src/components/info-page/PluginInfoPage.vue
+++ b/src/components/info-page/PluginInfoPage.vue
@@ -1,0 +1,197 @@
+<template>
+  <div class="plugin-info-page">
+    <div class="container">
+      <PluginHeader
+        :title="pluginConfig.name"
+        :subtitle="pluginConfig.description"
+        :icon="icon"
+        :status="status"
+      />
+
+      <PluginSection v-if="about" title="About">
+        <p>{{ about }}</p>
+        <PluginFeatureGrid v-if="features" :features="features" />
+      </PluginSection>
+
+      <PluginSection v-if="architecture" title="Architecture">
+        <p>{{ architecture.description }}</p>
+        <ul v-if="architecture.points">
+          <li v-for="(point, index) in architecture.points" :key="index">
+            <strong v-if="point.label">{{ point.label }}:</strong> {{ point.text }}
+          </li>
+        </ul>
+      </PluginSection>
+
+      <PluginSection title="Integration">
+        <p>To use this plugin in your TopLocs instance, add it to your plugin configuration:</p>
+        <PluginCodeBlock :code="integrationCode" />
+        <div v-if="pluginConfig.slots && pluginConfig.slots.length > 0">
+          <p>The plugin exposes components for the following slots:</p>
+          <ul>
+            <li v-for="slot in formattedSlots" :key="slot">
+              <span class="highlight">{{ slot.path }}</span> - {{ slot.description }}
+            </li>
+          </ul>
+        </div>
+      </PluginSection>
+
+      <PluginSection v-if="endpoints" title="Plugin Endpoints">
+        <p>The plugin is served via GitHub Pages with the following key endpoints:</p>
+        <ul>
+          <li><strong>Plugin Entry:</strong> <span class="highlight">{{ endpoints.plugin }}</span></li>
+          <li><strong>Landing Page:</strong> <span class="highlight">{{ endpoints.landing }}</span></li>
+          <li v-if="endpoints.demo"><strong>Live Demo:</strong> <span class="highlight">{{ endpoints.demo }}</span></li>
+        </ul>
+      </PluginSection>
+
+      <PluginSection v-if="development" title="Development">
+        <div v-if="development.stack">
+          <p>The {{ pluginConfig.name }} Plugin is built with:</p>
+          <ul>
+            <li v-for="tech in development.stack" :key="tech">{{ tech }}</li>
+          </ul>
+        </div>
+        
+        <div v-if="development.setup">
+          <p>To run locally:</p>
+          <PluginCodeBlock :code="development.setup" />
+        </div>
+        
+        <div v-if="development.urls">
+          <p><strong>Development URLs:</strong></p>
+          <ul>
+            <li v-for="url in development.urls" :key="url.label">
+              {{ url.label }}: <span class="highlight">{{ url.url }}</span>
+            </li>
+          </ul>
+        </div>
+      </PluginSection>
+
+      <PluginSection title="Resources">
+        <PluginLinks :links="computedLinks" />
+      </PluginSection>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { BasePluginConfig } from '../../types'
+import PluginHeader from './PluginHeader.vue'
+import PluginSection from './PluginSection.vue'
+import PluginFeatureGrid from './PluginFeatureGrid.vue'
+import PluginCodeBlock from './PluginCodeBlock.vue'
+import PluginLinks from './PluginLinks.vue'
+
+export interface PluginInfoProps {
+  pluginConfig: BasePluginConfig
+  icon?: string
+  status?: string
+  about?: string
+  features?: Array<{
+    icon: string
+    title: string
+    description: string
+  }>
+  architecture?: {
+    description: string
+    points?: Array<{
+      label?: string
+      text: string
+    }>
+  }
+  endpoints?: {
+    plugin?: string
+    landing?: string
+    demo?: string
+  }
+  development?: {
+    stack?: string[]
+    setup?: string
+    urls?: Array<{
+      label: string
+      url: string
+    }>
+  }
+  slotDescriptions?: Record<string, string>
+  links?: Array<{
+    href: string
+    label: string
+    primary?: boolean
+  }>
+}
+
+const props = withDefaults(defineProps<PluginInfoProps>(), {
+  icon: '🔌'
+})
+
+const defaultLinks = computed(() => [
+  { href: `https://github.com/toplocs/${props.pluginConfig.id.replace(/_/g, '-')}`, label: 'GitHub Repository', primary: true },
+  { href: 'https://github.com/toplocs/tribelike', label: 'TopLocs Platform' },
+  { href: 'https://toplocs.github.io/toplocs-workspace/', label: 'Documentation' }
+])
+
+const computedLinks = computed(() => props.links || defaultLinks.value)
+
+const integrationCode = computed(() => {
+  return JSON.stringify({
+    id: props.pluginConfig.id,
+    name: props.pluginConfig.name,
+    url: props.endpoints?.plugin || props.pluginConfig.url,
+    version: props.pluginConfig.version || '1.0.0',
+    description: props.pluginConfig.description,
+    author: props.pluginConfig.author || 'TopLocs Team'
+  }, null, 2)
+})
+
+const formattedSlots = computed(() => {
+  if (!props.pluginConfig.slots) return []
+  
+  const uniqueSlots = new Map()
+  props.pluginConfig.slots.forEach(slot => {
+    const path = `${slot.page}/${slot.slot}`
+    if (!uniqueSlots.has(path)) {
+      uniqueSlots.set(path, {
+        path,
+        description: props.slotDescriptions?.[`${slot.page}/${slot.slot}`] || `${slot.component} component`
+      })
+    }
+  })
+  
+  return Array.from(uniqueSlots.values())
+})
+</script>
+
+<style scoped>
+.plugin-info-page {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  line-height: 1.6;
+  color: #333;
+  background-color: #f8f9fa;
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+ul {
+  margin-left: 2rem;
+  margin-top: 0.5rem;
+}
+
+.highlight {
+  background: #e8f4ff;
+  padding: 0.2rem 0.4rem;
+  border-radius: 3px;
+  font-family: monospace;
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 1rem;
+  }
+}
+</style>

--- a/src/components/info-page/PluginLinks.vue
+++ b/src/components/info-page/PluginLinks.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="links">
+    <a v-for="link in links" 
+       :key="link.href" 
+       :href="link.href" 
+       :class="['link-button', { 'secondary': !link.primary }]"
+       target="_blank"
+       rel="noopener noreferrer">
+      {{ link.label }}
+    </a>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Link {
+  href: string
+  label: string
+  primary?: boolean
+}
+
+interface Props {
+  links: Link[]
+}
+
+defineProps<Props>()
+</script>
+
+<style scoped>
+.links {
+  display: flex;
+  gap: 1rem;
+  margin-top: 2rem;
+  flex-wrap: wrap;
+}
+
+.link-button {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: #3498db;
+  color: white;
+  text-decoration: none;
+  border-radius: 5px;
+  transition: background 0.3s;
+}
+
+.link-button:hover {
+  background: #2980b9;
+}
+
+.link-button.secondary {
+  background: #95a5a6;
+}
+
+.link-button.secondary:hover {
+  background: #7f8c8d;
+}
+</style>

--- a/src/components/info-page/PluginSection.vue
+++ b/src/components/info-page/PluginSection.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="plugin-section">
+    <h2>{{ title }}</h2>
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  title: string
+}
+
+defineProps<Props>()
+</script>
+
+<style scoped>
+.plugin-section {
+  background: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  margin-bottom: 2rem;
+}
+
+h2 {
+  color: #2c3e50;
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+}
+
+@media (max-width: 600px) {
+  .plugin-section {
+    padding: 1.5rem;
+  }
+}
+</style>

--- a/src/components/info-page/index.ts
+++ b/src/components/info-page/index.ts
@@ -1,0 +1,10 @@
+// Info page components for plugin landing pages
+export { default as PluginInfoPage } from './PluginInfoPage.vue'
+export { default as PluginHeader } from './PluginHeader.vue'
+export { default as PluginSection } from './PluginSection.vue'
+export { default as PluginFeatureGrid } from './PluginFeatureGrid.vue'
+export { default as PluginCodeBlock } from './PluginCodeBlock.vue'
+export { default as PluginLinks } from './PluginLinks.vue'
+
+// Export types
+export type { PluginInfoProps } from './PluginInfoPage.vue'

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,16 @@ export { default as DirectComponent } from './components/DirectComponent.vue'
 export { default as PluginComponent } from './components/PluginComponent.vue'
 export { default as App } from './App.vue'
 
+// Export info page components
+export { 
+  PluginInfoPage,
+  PluginHeader,
+  PluginSection,
+  PluginFeatureGrid,
+  PluginCodeBlock,
+  PluginLinks
+} from './components/info-page'
+
 // Export types
 export type { BasePluginConfig, PluginSlot, PluginDevConfig, FederationMethods } from './types'
+export type { PluginInfoProps } from './components/info-page'


### PR DESCRIPTION
## Summary
Adds reusable Vue components for creating consistent plugin landing pages across all TopLocs plugins.

## Features
- 🎨 **PluginInfoPage**: Main component that orchestrates the entire landing page
- 📋 **Modular Components**: Header, Section, FeatureGrid, CodeBlock, Links
- 🔧 **Customizable**: Props for plugin config, features, endpoints, development info
- 🎯 **Consistent Design**: Ensures all plugins have the same professional look
- ♻️ **DRY Principle**: Reusable components reduce code duplication

## Components Added
1. **PluginInfoPage** - Main landing page component
2. **PluginHeader** - Header with title, icon, and status badge
3. **PluginSection** - Reusable section wrapper
4. **PluginFeatureGrid** - Grid layout for feature showcase
5. **PluginCodeBlock** - Code snippet display
6. **PluginLinks** - Resource links with primary/secondary styling

## Usage Example
```vue
<template>
  <PluginInfoPage
    :plugin-config="pluginConfig"
    icon="📅"
    :about="about"
    :features="features"
    :endpoints="endpoints"
    :development="development"
  />
</template>

<script setup>
import { PluginInfoPage } from '@toplocs/plugin-sdk'
import pluginConfig from './src/index'
// ... define props data
</script>
```

## Benefits
- Consistent look across all plugin landing pages
- Easy to maintain and update
- Reduces code duplication
- Professional appearance out of the box

🤖 Generated with [Claude Code](https://claude.ai/code)